### PR TITLE
Update translated README screenshots

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -35,6 +35,8 @@ Oberfläche.
 - **Optionale Module und Sprachen:** Module in den Einstellungen ohne Neustart
   ein- oder ausblenden und die Oberfläche zwischen Portugiesisch, Englisch und
   Deutsch wechseln.
+<img width="927" height="607" alt="LANGUAGES DE" src="https://github.com/user-attachments/assets/f4c2a026-6c4a-403f-8602-8d0914e7dd21" />
+
 ## Voraussetzungen
 
 - Windows 10 oder neuer.

--- a/README.de.md
+++ b/README.de.md
@@ -2,7 +2,7 @@
 
 [Português (BR)](README.md) | [English](README.en.md) | [Deutsch](README.de.md)
 
-> Hinweis: Diese deutsche Übersetzung ist noch in Arbeit und entspricht möglicherweise noch nicht vollständig der neuesten portugiesischen Version.
+> Hinweis: Die vollständige deutsche Übersetzung ist noch in Arbeit und wird bald fertiggestellt. Diese Datei entspricht möglicherweise noch nicht vollständig der neuesten portugiesischen Version.
 
 Kostenlose Open-Source-Desktopanwendung zur Verwaltung von LAN-Servern für
 **Assetto Corsa Competizione (ACC)**.
@@ -14,25 +14,27 @@ Oberfläche.
 ## Funktionen
 
 - **LAN- / Radmin-Server:** Strecke, Fahrzeug, Sessions, Wetter und
-  Rennbedingungen konfigurieren sowie den Dedicated Server starten und stoppen.
+  Rennbedingungen konfigurieren, den Dedicated Server starten und stoppen sowie
+  seinen Status überwachen.
 <img width="1279" height="789" alt="SERVER - DE" src="https://github.com/user-attachments/assets/fd34fb56-8f04-45bb-9e16-82a9b74198d1" />
 
 - **Telemetrie:** MoTeC-Sessions und `.ld`-/`.ldx`-Dateien lesen, Rundenzeiten,
-  Geschwindigkeit, Bremsungen, G-Kräfte und Konstanz analysieren.
+  Geschwindigkeit, Bremsungen, G-Kräfte und Konstanz analysieren sowie
+  Streckenprofile aktualisieren.
 <img width="1278" height="945" alt="TELEMETRY DE" src="https://github.com/user-attachments/assets/18393002-10c1-47ad-83cd-0c7dad6f8000" />
 
-- **Setup-Verwaltung:** Setups anzeigen, filtern, bearbeiten und auf andere
-  Fahrzeuge oder Strecken kopieren.
+- **Setup-Verwaltung:** Setups anzeigen, filtern und bearbeiten, auf andere
+  Fahrzeuge oder Strecken kopieren, Reifendrücke für ACC 1.9 anpassen und
+  Setup-Vorschläge erstellen.
 <img width="1280" height="1389" alt="SETUPS DE" src="https://github.com/user-attachments/assets/ab42d7e2-d502-44b0-90a2-23ec0b5f5975" />
 
 - **Rangliste:** Beste Rundenzeiten an Supabase senden, nach Fahrzeug und
-  Strecke filtern und die Historie behalten.
+  Strecke filtern sowie die beste Zeit und Historie jedes Fahrers behalten.
 <img width="1279" height="789" alt="SERVER - DE" src="https://github.com/user-attachments/assets/fd34fb56-8f04-45bb-9e16-82a9b74198d1" />
 
 - **Optionale Module und Sprachen:** Module in den Einstellungen ohne Neustart
   ein- oder ausblenden und die Oberfläche zwischen Portugiesisch, Englisch und
   Deutsch wechseln.
-
 ## Voraussetzungen
 
 - Windows 10 oder neuer.

--- a/README.de.md
+++ b/README.de.md
@@ -2,6 +2,8 @@
 
 [Português (BR)](README.md) | [English](README.en.md) | [Deutsch](README.de.md)
 
+> Hinweis: Diese deutsche Übersetzung ist noch in Arbeit und entspricht möglicherweise noch nicht vollständig der neuesten portugiesischen Version.
+
 Kostenlose Open-Source-Desktopanwendung zur Verwaltung von LAN-Servern für
 **Assetto Corsa Competizione (ACC)**.
 
@@ -13,12 +15,20 @@ Oberfläche.
 
 - **LAN- / Radmin-Server:** Strecke, Fahrzeug, Sessions, Wetter und
   Rennbedingungen konfigurieren sowie den Dedicated Server starten und stoppen.
+<img width="1279" height="789" alt="SERVER - DE" src="https://github.com/user-attachments/assets/fd34fb56-8f04-45bb-9e16-82a9b74198d1" />
+
 - **Telemetrie:** MoTeC-Sessions und `.ld`-/`.ldx`-Dateien lesen, Rundenzeiten,
   Geschwindigkeit, Bremsungen, G-Kräfte und Konstanz analysieren.
+<img width="1278" height="945" alt="TELEMETRY DE" src="https://github.com/user-attachments/assets/18393002-10c1-47ad-83cd-0c7dad6f8000" />
+
 - **Setup-Verwaltung:** Setups anzeigen, filtern, bearbeiten und auf andere
   Fahrzeuge oder Strecken kopieren.
+<img width="1280" height="1389" alt="SETUPS DE" src="https://github.com/user-attachments/assets/ab42d7e2-d502-44b0-90a2-23ec0b5f5975" />
+
 - **Rangliste:** Beste Rundenzeiten an Supabase senden, nach Fahrzeug und
   Strecke filtern und die Historie behalten.
+<img width="1279" height="789" alt="SERVER - DE" src="https://github.com/user-attachments/assets/fd34fb56-8f04-45bb-9e16-82a9b74198d1" />
+
 - **Optionale Module und Sprachen:** Module in den Einstellungen ohne Neustart
   ein- oder ausblenden und die Oberfläche zwischen Portugiesisch, Englisch und
   Deutsch wechseln.

--- a/README.en.md
+++ b/README.en.md
@@ -2,7 +2,7 @@
 
 [Português (BR)](README.md) | [English](README.en.md) | [Deutsch](README.de.md)
 
-> Note: this English translation is still in progress and may not yet match the latest Portuguese version exactly.
+> Note: the full English translation is still in progress and will be completed soon. This file may not yet match the latest Portuguese version exactly.
 
 Free and open-source desktop application for managing **Assetto Corsa
 Competizione (ACC)** LAN servers.
@@ -31,7 +31,6 @@ management, friends leaderboard and Discord notifications in one interface.
 - **Optional modules and languages:** enable or hide each module in Settings
   without restarting, and switch the interface between Portuguese, English and
   German at runtime.
-
 ## Requirements
 
 - Windows 10 or later.

--- a/README.en.md
+++ b/README.en.md
@@ -31,6 +31,8 @@ management, friends leaderboard and Discord notifications in one interface.
 - **Optional modules and languages:** enable or hide each module in Settings
   without restarting, and switch the interface between Portuguese, English and
   German at runtime.
+<img width="927" height="607" alt="LANGUAGES EN" src="https://github.com/user-attachments/assets/f4c2a026-6c4a-403f-8602-8d0914e7dd21" />
+
 ## Requirements
 
 - Windows 10 or later.

--- a/README.en.md
+++ b/README.en.md
@@ -2,6 +2,8 @@
 
 [Português (BR)](README.md) | [English](README.en.md) | [Deutsch](README.de.md)
 
+> Note: this English translation is still in progress and may not yet match the latest Portuguese version exactly.
+
 Free and open-source desktop application for managing **Assetto Corsa
 Competizione (ACC)** LAN servers.
 
@@ -12,12 +14,20 @@ management, friends leaderboard and Discord notifications in one interface.
 
 - **LAN / Radmin server:** configure track, car, sessions, weather and race
   conditions; start and stop the dedicated server; monitor its status.
+<img width="1279" height="789" alt="SERVER - EN" src="https://github.com/user-attachments/assets/fd34fb56-8f04-45bb-9e16-82a9b74198d1" />
+
 - **Telemetry:** read MoTeC sessions and `.ld`/`.ldx` files, inspect lap times,
   speed, braking, G-forces and consistency, and update track profiles.
+<img width="1278" height="945" alt="TELEMETRY EN" src="https://github.com/user-attachments/assets/18393002-10c1-47ad-83cd-0c7dad6f8000" />
+
 - **Setup manager:** list, filter, view and edit setups; replicate setups to
   other cars or tracks; adjust ACC 1.9 pressures; create setup suggestions.
+<img width="1280" height="1389" alt="SETUPS EN" src="https://github.com/user-attachments/assets/ab42d7e2-d502-44b0-90a2-23ec0b5f5975" />
+
 - **Leaderboard:** publish best laps to Supabase, filter by car and track, and
   keep each driver's best time and history.
+<img width="1279" height="789" alt="SERVER - EN" src="https://github.com/user-attachments/assets/fd34fb56-8f04-45bb-9e16-82a9b74198d1" />
+
 - **Optional modules and languages:** enable or hide each module in Settings
   without restarting, and switch the interface between Portuguese, English and
   German at runtime.

--- a/README.md
+++ b/README.md
@@ -15,20 +15,27 @@ as notificações via Discord.
   - Inicia e encerra o servidor dedicado do ACC.
   - Configura pista, carro, sessões, clima e condições de corrida.
   - Exibe o status do servidor e envia notificações para o Discord.
+ <img width="1279" height="789" alt="SERVER - PT BR" src="https://github.com/user-attachments/assets/fd34fb56-8f04-45bb-9e16-82a9b74198d1" />
+
 - **Telemetria**
   - Lê sessões gravadas pelo MoTeC.
   - Analisa arquivos `.ld` e `.ldx`.
   - Exibe voltas, tempos, velocidade média, frenagens, forças G e consistência.
   - Ajusta perfis de pistas com base nos dados de telemetria.
+ <img width="1278" height="945" alt="TELEMETRY PT-BR" src="https://github.com/user-attachments/assets/18393002-10c1-47ad-83cd-0c7dad6f8000" />
+
 - **Gerenciador de setups**
   - Lista, filtra, visualiza e edita setups do ACC.
   - Replica setups para outros carros ou pistas.
   - Ajusta pressões para compatibilidade com o ACC 1.9.
   - Cria sugestões de setup com base no carro, pista e estilo de condução.
+ <img width="1280" height="1389" alt="SETUPS PT-BR" src="https://github.com/user-attachments/assets/ab42d7e2-d502-44b0-90a2-23ec0b5f5975" />
+
 - **Ranking**
   - Publica melhores tempos em uma tabela compartilhada no Supabase.
   - Filtra resultados por carro e pista.
   - Mantém o histórico de voltas e o melhor tempo de cada piloto.
+<img width="1279" height="789" alt="SERVER - PT BR" src="https://github.com/user-attachments/assets/fd34fb56-8f04-45bb-9e16-82a9b74198d1" />
 
 - **Módulos e idiomas**
   - Ative ou desative as abas de servidor, telemetria, setups e ranking

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ as notificações via Discord.
     individualmente nas configurações, sem reiniciar o programa.
   - Troque o idioma da interface em tempo real entre português, inglês e
     alemão.
-
 ## Requisitos
 
 - Windows 10 ou superior.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ as notificações via Discord.
     individualmente nas configurações, sem reiniciar o programa.
   - Troque o idioma da interface em tempo real entre português, inglês e
     alemão.
+<img width="927" height="607" alt="LANGUAGES PT-BR" src="https://github.com/user-attachments/assets/f4c2a026-6c4a-403f-8602-8d0914e7dd21" />
+
 ## Requisitos
 
 - Windows 10 ou superior.


### PR DESCRIPTION
Atualiza README.en.md e README.de.md com as imagens, mantém a nota de tradução integral em andamento e remove a referência antiga da imagem de configurações. O README.md em português também recebe a imagem segura atualizada.