### PR TITLE
Add open source contribution structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Mantenedor atual determinado pelo proprietário da organização/repositório.
+* @kalichak

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Reportar um comportamento incorreto ou uma falha reproduzível
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Não inclua credenciais, webhooks, arquivos `.env`, screenshots de configurações ou telemetria pessoal.
+  - type: input
+    id: version
+    attributes:
+      label: Versão/commit
+      description: Informe a versão ou o commit usado.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Como reproduzir
+      description: Liste os passos mínimos.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportamento esperado
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Comportamento observado
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Ambiente
+      description: Windows, Python, ACC/MoTeC quando relevante.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,21 @@
+name: Documentation
+description: Sugerir uma correção ou melhoria na documentação
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Arquivo ou seção
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: O que está incorreto ou faltando
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Melhoria proposta

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Sugerir uma melhoria compatível com a arquitetura atual
+title: "[Feature]: "
+labels: ["feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problema ou necessidade
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposta
+      description: Explique o comportamento desejado e o módulo afetado.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternativas consideradas
+  - type: textarea
+    id: scope
+    attributes:
+      label: Impacto e limitações
+      description: Inclua integrações externas, dados ou compatibilidade.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Resumo
+
+Descreva o problema e a solução.
+
+## Área afetada
+
+- [ ] UI
+- [ ] Server
+- [ ] Telemetry
+- [ ] Setups
+- [ ] Ranking
+- [ ] Configuration
+- [ ] Build/CI
+- [ ] Documentation
+
+## Validação
+
+- [ ] `python -m compileall -q config.py core ui main.py test_discord_webhook.py`
+- [ ] `python -m pytest -q`
+- [ ] `.\build_exe.bat` (quando aplicável)
+- [ ] Documentação atualizada
+
+Descreva outros testes manuais e limitações. Não anexe credenciais, webhooks,
+`.env`, `ui_settings.json` ou screenshots com dados sensíveis.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Windows build
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v*"]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build distributable
+        shell: cmd
+        run: build_exe.bat

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,30 @@
+name: Python quality
+
+on:
+  push:
+    branches: ["main", "feature/**"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  validate:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Compile Python sources
+        run: python -m compileall -q config.py core ui main.py test_discord_webhook.py
+      - name: Run automated tests when present
+        shell: pwsh
+        run: |
+          $tests = Get-ChildItem -Recurse -Filter "test_*.py" |
+            Select-String -Pattern "^\s*(def test_|class Test)" -List
+          if ($tests) {
+            python -m pytest -q
+          } else {
+            Write-Host "No automated pytest tests are currently present."
+          }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contribuindo para o ACC Manager
+
+Obrigado por considerar uma contribuição. O ACC Manager é uma aplicação
+desktop para Windows, escrita em Python com PyQt6, e aceita melhorias de
+ código, documentação, dados de carros/pistas e suporte ao desenvolvimento.
+
+## Antes de começar
+
+Leia [docs/START_HERE.md](docs/START_HERE.md), [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+e [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md). Para mudanças de comportamento,
+consulte também o módulo correspondente em `docs/`.
+
+Nunca envie `.env`, `ui_settings.json`, credenciais, webhooks ou dados
+extraídos de telemetria. Use valores vazios ou exemplos fictícios.
+
+## Configurando o ambiente
+
+Requisitos:
+
+- Windows 10 ou superior.
+- Python 3.10 ou superior.
+- Assetto Corsa Competizione para testar integrações reais.
+- MoTeC i2 Pro e arquivos de telemetria apenas para trabalhar no módulo de
+  telemetria.
+
+```powershell
+python -m venv venv
+.\venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+python main.py
+```
+
+O aplicativo cria `.env` na primeira execução. Consulte
+[docs/CONFIGURATION.md](docs/CONFIGURATION.md) para configurar caminhos e
+integrações sem expor segredos.
+
+## Estrutura e branches
+
+Use uma branch curta baseada em `main`:
+
+```powershell
+git switch main
+git pull --ff-only
+git switch -c tipo/descricao-curta
+```
+
+Prefira `feature/`, `fix/`, `docs/`, `refactor/` ou `ci/`. Não desenvolva
+diretamente em `main`.
+
+## Testes e validações
+
+Antes de abrir um Pull Request:
+
+```powershell
+python -m compileall -q config.py core ui main.py test_discord_webhook.py
+python -m pytest -q
+```
+
+O arquivo `test_discord_webhook.py` é um teste manual de integração, não um
+teste automatizado seguro para CI: ele envia mensagens reais se houver um
+webhook no `.env`. Não execute esse script em CI nem inclua um webhook no
+repositório. O projeto ainda não possui uma suíte automatizada abrangente.
+
+Para validar o empacotamento no Windows:
+
+```powershell
+.\build_exe.bat
+```
+
+Distribua a pasta inteira `dist\ACCManager`, conforme
+[EMPACOTAMENTO.md](EMPACOTAMENTO.md).
+
+## Commits
+
+Escreva mensagens claras no imperativo e mantenha cada commit focado:
+
+```text
+Add German translations for telemetry labels
+Fix setup replication for missing target directories
+Document Supabase configuration
+```
+
+Não inclua segredos, arquivos gerados ou alterações não relacionadas.
+
+## Pull Requests
+
+Um Pull Request deve:
+
+1. Explicar o problema e a solução.
+2. Indicar os arquivos e módulos afetados.
+3. Descrever como validar a mudança.
+4. Informar limitações, dependências externas ou passos manuais.
+5. Incluir screenshots para mudanças visuais, sem dados pessoais ou segredos.
+
+O template solicitará essas informações. Mudanças maiores devem incluir ou
+atualizar documentação e, quando aplicável, um ADR em `docs/decisions/`.
+
+## Dados e licenças
+
+Carros e pistas são mantidos em `core/data/cars.json` e
+`core/data/tracks.json`. O código principal está sob MIT, mas
+`core/vendor/ldparser.py` possui licença GPLv3 própria. Leia
+[docs/LICENSING.md](docs/LICENSING.md) antes de redistribuir ou alterar
+componentes de terceiros.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [Português (BR)](README.md) | [English](README.en.md) | [Deutsch](README.de.md)
 
+## Para contribuidores
+
+- [Comece aqui](docs/START_HERE.md)
+- [Guia de contribuição](CONTRIBUTING.md)
+- [Arquitetura](docs/ARCHITECTURE.md)
+- [Roadmap](ROADMAP.md)
+- [Mapa de contribuidores](docs/CONTRIBUTOR_MAP.md)
+
 Aplicativo desktop gratuito e open source para gerenciamento de servidores
 LAN do **Assetto Corsa Competizione (ACC)**.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,27 @@
+# Roadmap
+
+Este roadmap separa o que já existe do que são oportunidades futuras. Ele não
+promete prazos.
+
+## Já existe
+
+- Controle local de ACC Dedicated Server.
+- Leitura de sessões MoTeC `.ldx` e análise avançada `.ld`.
+- Gerenciamento, replicação, presets e criação inteligente de setups.
+- Calibração de perfis de pista a partir de dados reais.
+- Ranking compartilhado via Supabase.
+- Notificações por Discord webhook.
+- Módulos opcionais e troca de idioma em tempo de execução para português,
+  inglês e alemão.
+- Build Windows PyInstaller `--onedir`.
+
+## Próximas oportunidades
+
+- Construir uma suíte automatizada de testes para parsers, configuração,
+  setups e clientes externos.
+- Melhorar cobertura e consistência das traduções restantes.
+- Validar arquivos de configuração do ACC antes de iniciar o servidor.
+- Melhorar observabilidade e mensagens de erro sem expor credenciais.
+- Adicionar histórico visual ao ranking.
+- Expandir suporte de telemetria com fixtures seguras e formatos adicionais.
+- Evoluir a separação dos mixins de UI quando houver necessidade real.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,81 @@
+# Arquitetura real
+
+## Visão geral
+
+O ACC Manager é uma aplicação desktop PyQt6 executada por `main.py`. Não há
+backend próprio: integrações externas são feitas diretamente pelos serviços em
+`core/` usando arquivos locais, processos do ACC, REST do Supabase e webhooks
+do Discord.
+
+```text
+main.py
+  -> ui.main_window.ACCManagerApp
+       -> ui/*_tab.py (mixins das abas)
+       -> ui/settings_dialog.py e ui/i18n.py
+       -> core/* (serviços)
+            -> arquivos do ACC/MoTeC/Setups
+            -> Supabase REST
+            -> Discord Webhook
+```
+
+## Inicialização
+
+`main.py` cria `QApplication`, aplica `ui.styles.DARK_STYLE`, configura o
+ícone e instancia `ACCManagerApp`. `config.py` é importado durante a
+inicialização: resolve a pasta base, lê ou cria `.env`, carrega os dados JSON,
+importa os serviços e expõe as constantes usadas pela UI.
+
+`ui/main_window.py` cria os serviços (`ServerController`, `MotecParser`,
+`SetupManager`, `SetupCreator`, `LeaderboardClient` e `DiscordNotifier`) e
+compõe as abas por herança múltipla de mixins. Os mixins não são widgets
+independentes; a janela principal fornece o estado e os serviços usados por
+eles.
+
+## UI
+
+- `ui/main_window.py`: janela, abas habilitadas, persistência de
+  `ui_settings.json`, troca de idioma e reconstrução após configurações.
+- `ui/server_tab.py`: formulário do servidor, clima, sessões e preview de
+  pista.
+- `ui/telemetry_tab.py`: lista de sessões MoTeC, filtros, detalhes e análise
+  avançada `.ld`.
+- `ui/setups_tab.py`: lista/edição de setups, presets, replicação, criador
+  inteligente e análise.
+- `ui/leaderboard_tab.py`: identidade do piloto, filtros, envio ao Supabase e
+  ranking.
+- `ui/settings_dialog.py`: edição de caminhos, integrações e módulos ativos.
+- `ui/i18n.py`: dicionário em memória para português, inglês e alemão.
+- `ui/styles.py` e `ui/dialogs.py`: tema e diálogos auxiliares.
+
+## Core
+
+- `server_controller.py`: escreve `settings.json`, `configuration.json` e
+  `event.json` em UTF-16LE, inicia/encerra `accServer.exe` e limpa `current`.
+- `motec_parser.py`: lê resumos XML `.ldx`, extrai volta, carro, pista, data e
+  condições.
+- `ld_telemetry_parser.py`: usa `core/vendor/ldparser.py` e marcadores `.ldx`
+  para analisar canais binários `.ld`.
+- `setup_manager.py`: lista, lê, salva, remove, clona e replica JSON de setups.
+- `setup_creator.py`: gera variações de um setup válido com perfis de carro,
+  pista, agressividade e condição.
+- `track_profile_calibrator.py`: calcula e grava sugestões de perfil de pista
+  a partir de voltas e telemetria.
+- `leaderboard_client.py`: cliente REST insert/select do Supabase e redução
+  do histórico ao melhor tempo por piloto/carro/pista.
+- `discord_notifier.py`: envia mensagens e embeds por webhook.
+- `data_loader.py`: fonte única, com cache por mtime, para
+  `core/data/cars.json` e `core/data/tracks.json`.
+
+## Dados e empacotamento
+
+`assets/` contém imagens de pistas e o ícone. `build_exe.bat` gera um
+distribuível PyInstaller `--onedir`, incluindo `core/data`, `assets` e a
+licença vendorizada. `--onedir` é necessário porque a calibração pode gravar
+em `core/data/tracks.json`.
+
+## Fluxo de configuração
+
+`.env` contém caminhos, idioma, módulos habilitados e credenciais opcionais.
+`ui_settings.json` guarda valores de campos da UI. A tela de configurações
+salva `.env`; `config.reload_env()` atualiza constantes e a janela reconstrói
+abas e serviços sem reiniciar.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,32 @@
+# Configuração
+
+## Arquivos
+
+- `.env`: caminhos, idioma, módulos e credenciais opcionais. É criado
+  automaticamente e ignorado pelo Git.
+- `ui_settings.json`: valores persistidos dos campos da interface; também é
+  local e ignorado.
+- `core/data/cars.json`: nomes, classes e temperamento dos carros.
+- `core/data/tracks.json`: nomes, comprimento e perfis das pistas.
+
+## Variáveis do `.env`
+
+| Variável | Uso |
+|---|---|
+| `ACC_SERVER_PATH` | Pasta que contém `accServer.exe`. |
+| `ACC_MOTEC_PATH` | Pasta dos arquivos `.ldx`/`.ld`. |
+| `ACC_SETUPS_PATH` | Raiz dos setups `carro\pista`. |
+| `SUPABASE_URL` | URL do projeto Supabase, opcional. |
+| `SUPABASE_KEY` | Chave pública `anon`, opcional. |
+| `DISCORD_WEBHOOK_URL` | Webhook Discord, opcional. |
+| `ENABLED_MODULES` | Lista separada por vírgula: `server`, `telemetry`, `setups`, `leaderboard`. |
+| `APP_LANGUAGE` | `pt`, `en` ou `de`. |
+
+Use a tela de Configurações para editar os valores. O idioma e os módulos
+podem ser alterados em tempo de execução; a janela é reconstruída sem reinício.
+
+## Segurança
+
+Não publique `.env`, chaves, webhooks, `ui_settings.json`, screenshots de
+configurações ou arquivos de telemetria. A chave `anon` é pública por desenho,
+mas ainda deve ser configurada localmente e acompanhada de RLS apropriada.

--- a/docs/CONTRIBUTOR_MAP.md
+++ b/docs/CONTRIBUTOR_MAP.md
@@ -1,0 +1,15 @@
+# Mapa para contribuidores
+
+| Área | Onde procurar | Responsabilidade |
+|---|---|---|
+| UI | `ui/main_window.py`, `ui/*_tab.py`, `ui/settings_dialog.py` | Widgets, eventos, composição e configurações |
+| Server | `ui/server_tab.py`, `core/server_controller.py` | Formulário e controle do Dedicated Server |
+| Telemetry | `ui/telemetry_tab.py`, `core/motec_parser.py`, `core/ld_telemetry_parser.py` | `.ldx`, `.ld`, métricas e scores |
+| Setups | `ui/setups_tab.py`, `core/setup_manager.py`, `core/setup_creator.py` | JSON de setups, presets e criação inteligente |
+| Ranking | `ui/leaderboard_tab.py`, `core/leaderboard_client.py` | Supabase, melhores tempos e filtros |
+| Configuration | `config.py`, `ui/settings_dialog.py`, `.env` | Caminhos, idioma, módulos e credenciais |
+| Build/Infrastructure | `build_exe.bat`, `ACCManager.spec`, `EMPACOTAMENTO.md`, `.github/` | PyInstaller, CI e manutenção |
+| Documentation | `README*.md`, `CONTRIBUTING.md`, `docs/` | Uso, arquitetura e processo |
+
+Dados de carros e pistas ficam em `core/data/`; imagens e ícone ficam em
+`assets/`. O arquivo `test_discord_webhook.py` é um teste manual de integração.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,46 @@
+# Desenvolvimento
+
+## Ambiente
+
+```powershell
+python -m venv venv
+.\venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+```
+
+O projeto depende de PyQt6, psutil, requests, numpy e pytest. O sistema
+operacional suportado pelo fluxo real de desenvolvimento e build é Windows.
+
+## Execução
+
+```powershell
+python main.py
+# ou
+.\run_acc_manager.bat
+```
+
+O `.env` e `ui_settings.json` são locais. Se o PowerShell bloquear a ativação,
+use `Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned`.
+
+## Validação
+
+```powershell
+python -m compileall -q config.py core ui main.py test_discord_webhook.py
+python -m pytest -q
+```
+
+Não existe atualmente uma suíte automatizada abrangente. O teste existente de
+webhook é manual e envia requisições reais; não o execute com credenciais em
+CI.
+
+## Convenções
+
+Mantenha a lógica de integração em `core/`, a composição/experiência em `ui/`
+e os dados de carros/pistas em JSON. Evite duplicar a fonte de dados em Python.
+Mudanças de comportamento devem atualizar a documentação correspondente.
+
+## Build
+
+`build_exe.bat` instala PyInstaller, limpa `build/` e `dist/` e gera
+`dist\ACCManager\ACCManager.exe`. Consulte `EMPACOTAMENTO.md` antes de alterar
+o processo.

--- a/docs/GOOD_FIRST_ISSUES.md
+++ b/docs/GOOD_FIRST_ISSUES.md
@@ -1,0 +1,30 @@
+# Oportunidades de contribuição
+
+As sugestões abaixo são baseadas no código atual. Elas são propostas de
+trabalho; não são Issues GitHub abertas automaticamente.
+
+| Categoria | Dificuldade | Sugestão |
+|---|---|---|
+| good first issue | easy | Adicionar teste unitário para `data_loader.normalize`. |
+| good first issue | easy | Documentar todas as chaves de `core/data/cars.json`. |
+| good first issue | easy | Documentar todas as chaves de `core/data/tracks.json`. |
+| good first issue | easy | Adicionar validação de formato para `APP_LANGUAGE`. |
+| documentation | easy | Traduzir mensagens restantes que ainda usam strings diretas na UI. |
+| documentation | easy | Adicionar exemplos de troubleshooting para caminhos OneDrive. |
+| documentation | medium | Documentar o schema efetivo dos três JSON escritos pelo servidor. |
+| help wanted | medium | Criar fixtures pequenos de `.ldx` para testar o parser sem dados pessoais. |
+| help wanted | medium | Criar testes de `MotecParser` com XML mínimo e nomes de arquivo variados. |
+| help wanted | medium | Criar testes de `SetupManager` usando diretório temporário. |
+| bug | medium | Tratar arquivos `.ldx` corrompidos com feedback específico em vez de apenas ignorá-los. |
+| bug | medium | Revisar a descoberta de caminhos quando o Windows usa nomes diferentes para OneDrive. |
+| bug | hard | Tornar a remoção de processos do servidor mais restrita ao servidor configurado. |
+| refactor | medium | Extrair a persistência de `ui_settings.json` para um serviço testável. |
+| refactor | medium | Substituir strings restantes de UI por chaves centralizadas em `ui/i18n.py`. |
+| refactor | hard | Separar os mixins de abas em widgets independentes sem alterar o fluxo atual. |
+| feature | medium | Adicionar importação/exportação explícita de uma configuração sem segredos. |
+| feature | medium | Permitir escolher o limite de score para tempos inválidos. |
+| feature | hard | Adicionar uma visualização histórica de evolução no ranking. |
+| feature | hard | Adicionar suporte a mais formatos de telemetria sem remover o caminho `.ldx`. |
+
+Antes de implementar uma sugestão, confirme o comportamento com um mantenedor
+e não inclua arquivos reais do ACC, MoTeC, Supabase ou Discord.

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -1,0 +1,29 @@
+# Licenciamento
+
+## Projeto
+
+O código do ACC Manager é distribuído sob a [MIT License](../LICENSE). A MIT
+permite uso, modificação e redistribuição, inclusive comercial, mantendo o
+aviso de copyright e o texto da licença.
+
+## Componente GPLv3
+
+`core/vendor/ldparser.py` é um componente vendorizado sob GNU GPLv3. O texto
+completo está em `core/vendor/LICENSE-ldparser.txt`. A licença desse arquivo
+não é substituída pela MIT do projeto principal.
+
+Ao modificar ou redistribuir o componente vendorizado, preserve seus avisos,
+ofereça o código-fonte correspondente conforme a GPLv3 e não apresente o
+componente como se fosse MIT. O build inclui a licença em `core/vendor`.
+
+Esta documentação não é aconselhamento jurídico. Questões sobre combinação,
+distribuição de executáveis ou alterações substanciais devem ser revisadas por
+alguém com competência jurídica. Não altere nenhuma licença sem autorização
+do mantenedor.
+
+## Outras dependências
+
+`requirements.txt` declara PyQt6, psutil, requests, numpy e pytest. As
+licenças e avisos dessas dependências devem ser verificados nas versões
+instaladas antes de uma redistribuição comercial; o repositório não mantém
+cópias completas desses textos.

--- a/docs/RANKING.md
+++ b/docs/RANKING.md
@@ -1,0 +1,26 @@
+# Ranking
+
+## Integração
+
+`core/leaderboard_client.py` acessa diretamente a API REST do Supabase. Não há
+servidor intermediário. A aba `ui/leaderboard_tab.py` envia os melhores tempos
+MoTeC e mostra o melhor resultado por piloto, carro e pista.
+
+O ranking usa uma tabela `leaderboard` com histórico insert-only. As políticas
+RLS documentadas no README permitem `insert` e `select` para a chave pública
+`anon`; não há update/delete público configurado pelo projeto.
+
+## Configuração
+
+Defina `SUPABASE_URL` e `SUPABASE_KEY` no `.env`. Use somente a chave
+`anon public`; nunca use `service_role` em um cliente distribuído.
+
+Se as chaves estiverem vazias, o aplicativo continua funcionando e apenas o
+ranking compartilhado fica desabilitado. O Discord pode notificar novos
+recordes quando `DISCORD_WEBHOOK_URL` estiver configurado.
+
+## Contribuindo
+
+Não inclua URL, chave, payload ou screenshot reais. Testes de rede devem usar
+um projeto descartável e não devem ser executados automaticamente em CI.
+Mudanças no schema precisam atualizar o SQL do README e esta documentação.

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -1,0 +1,32 @@
+# Servidor
+
+## Responsabilidade
+
+`core/server_controller.py` controla um ACC Dedicated Server local. A aba
+correspondente é `ui/server_tab.py`.
+
+## Fluxo
+
+Ao iniciar, a UI salva as configurações, valida requisitos de servidor,
+interrompe uma instância anterior quando necessário, opcionalmente remove
+`cfg/current`, grava três arquivos JSON e executa `accServer.exe` no diretório
+configurado.
+
+- `settings.json`: nome, senhas, vagas e requisitos de rating.
+- `configuration.json`: portas, descoberta LAN e lobby.
+- `event.json`: pista, sessões, horário e clima.
+
+Os JSON do servidor são escritos em UTF-16LE conforme esperado pelo ACC.
+Parar o servidor procura processos chamados `accServer.exe` usando `psutil`.
+
+## Configuração
+
+Defina `ACC_SERVER_PATH` apontando para a pasta que contém `accServer.exe`.
+O controle é opcional: a aplicação pode ser usada sem habilitar a aba.
+
+## Contribuindo
+
+Teste primeiro com uma instalação local do Dedicated Server e nunca inclua
+arquivos `cfg`, senhas ou logs reais no commit. Mudanças no formato dos JSON
+devem ser comparadas com a documentação/versão do ACC utilizada pelo
+contribuidor; o projeto não valida esses esquemas externamente.

--- a/docs/SETUPS.md
+++ b/docs/SETUPS.md
@@ -1,0 +1,26 @@
+# Setups
+
+## Estrutura dos dados
+
+`core/setup_manager.py` percorre `ACC_SETUPS_PATH` no formato
+`carro\pista\arquivo.json`. A UI de `ui/setups_tab.py` lista, filtra, edita,
+salva, remove, clona e replica esses arquivos.
+
+## Recursos existentes
+
+- presets Qualy, Corrida e Chuva;
+- ajuste opcional de pressão para ACC 1.9 ao replicar;
+- Criador de Setup Inteligente baseado em setup válido, perfil de carro,
+  perfil de pista, agressividade e condição;
+- calibração de perfis da pista com dados MoTeC;
+- análise exibida pelo Engenheiro de Pista Virtual.
+
+O criador não gera JSON do zero: parte de um setup exportado pelo ACC para
+respeitar faixas específicas de cada carro.
+
+## Alterações seguras
+
+Preserve a estrutura esperada pelo ACC e faça backup de setups antes de testar.
+Não committe setups pessoais. Ao adicionar um parâmetro, trate arquivos
+antigos que não possuam a chave e mantenha o comportamento de cópia profunda
+usado nos presets.

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,0 +1,38 @@
+# Comece aqui
+
+Este guia é o caminho mais curto para entender o ACC Manager e fazer a
+primeira contribuição.
+
+## 1. Prepare o ambiente
+
+Use Windows 10+, Python 3.10+ e uma virtualenv. Instale
+`requirements.txt` e execute `python main.py`. O programa é uma GUI PyQt6;
+não é necessário um servidor local para iniciar a janela.
+
+## 2. Leia nesta ordem
+
+1. `README.md` — instalação e recursos visíveis ao usuário.
+2. `main.py` e `config.py` — entrada da aplicação e inicialização.
+3. `ui/main_window.py` — composição das abas e serviços.
+4. `ui/i18n.py` — traduções.
+5. A documentação do módulo que você pretende alterar.
+6. `core/data/*.json` — base de carros e pistas.
+
+## 3. Faça uma mudança pequena
+
+Escolha um item de [GOOD_FIRST_ISSUES.md](GOOD_FIRST_ISSUES.md), crie uma
+branch e preserve a separação entre UI (`ui/`) e serviços (`core/`). Para
+novos textos de interface, adicione as chaves nos três idiomas em
+`ui/i18n.py`.
+
+## 4. Valide
+
+Execute a compilação Python e `pytest`. Para mudanças de empacotamento, rode
+`build_exe.bat` em Windows. Não use credenciais reais em exemplos, screenshots
+ou commits.
+
+## 5. Envie
+
+Abra um Pull Request usando o template. Explique o comportamento anterior,
+o novo comportamento e como testar. Para decisões arquiteturais duradouras,
+adicione um ADR em `docs/decisions/`.

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,0 +1,33 @@
+# Telemetria
+
+## Fontes
+
+`core/motec_parser.py` lê arquivos `.ldx` na pasta `ACC_MOTEC_PATH`. O nome do
+arquivo fornece tokens de pista, carro e piloto; o XML fornece tempo mais
+rápido, voltas, sessão e temperaturas.
+
+`core/ld_telemetry_parser.py` faz a análise avançada do `.ld` irmão. Usa
+marcadores `BCN` do `.ldx` para separar voltas e extrai, quando disponíveis,
+velocidade, acelerador, freio, G-LAT/G-LON, temperaturas e RPM.
+
+## Fluxo na UI
+
+`ui/telemetry_tab.py` lista as melhores sessões, filtra por carro/pista,
+mostra preview da pista e abre a análise `.ld`. Sessões podem ser removidas;
+a remoção apaga o `.ldx` e o `.ld` correspondente.
+
+Tempos abaixo de 70 segundos são tratados pela UI como glitch para cálculo de
+score. Esse limite é comportamento atual, não uma regra configurável.
+
+## Calibração
+
+`core/track_profile_calibrator.py` calcula `avg_speed` pela distância em
+`tracks.json` e tempo de volta. Para `brake_stress`, usa eventos de frenagem
+forte da análise `.ld`. A aplicação pode gravar sugestões em
+`core/data/tracks.json`; por isso o build usa `--onedir`.
+
+## Contribuindo
+
+Use cópias de `.ld`/`.ldx` sem dados pessoais. Não envie sessões reais ao
+repositório. O parser vendorizado tem licença GPLv3; consulte
+[LICENSING.md](LICENSING.md).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,37 @@
+# Solução de problemas
+
+## PyQt6 ou dependências ausentes
+
+Ative a virtualenv e rode `pip install -r requirements.txt`. Se o erro ocorre
+ao abrir o executável, gere novamente com `build_exe.bat` e distribua a pasta
+inteira `dist\ACCManager`.
+
+## Caminho não encontrado
+
+Confira `ACC_SERVER_PATH`, `ACC_MOTEC_PATH` e `ACC_SETUPS_PATH`. A aplicação
+mostra um aviso na inicialização quando uma pasta habilitada não existe.
+
+## Servidor não inicia
+
+Confirme que `accServer.exe` existe no caminho configurado, que os arquivos
+podem ser escritos em `cfg` e que outra instância não está bloqueando o
+processo. Use o build `--console` temporariamente para obter erros de
+inicialização do empacotamento.
+
+## Telemetria ou setups vazios
+
+Confirme a estrutura de pastas e extensões. Telemetria resumida usa `.ldx` e a
+análise avançada requer o `.ld` correspondente. Setups são procurados em
+`ACC_SETUPS_PATH\carro\pista\*.json`.
+
+## Ranking ou Discord desconectado
+
+Verifique URL, chave `anon`, tabela/políticas RLS e conectividade. Para Discord,
+confirme que o webhook ainda existe. Não cole credenciais em issues; redija
+logs e screenshots antes de anexá-los.
+
+## Idioma ou módulos
+
+Valores reconhecidos são `pt`, `en`, `de` e os quatro nomes de módulos
+documentados em [CONFIGURATION.md](CONFIGURATION.md). Textos novos devem ter
+chave nos três blocos de `ui/i18n.py`.

--- a/docs/decisions/0001-desktop-pyqt6-e-onedir.md
+++ b/docs/decisions/0001-desktop-pyqt6-e-onedir.md
@@ -1,0 +1,25 @@
+# ADR 0001: Aplicação desktop PyQt6 empacotada como onedir
+
+- Status: aceito
+- Data: 2026-09-06
+
+## Contexto
+
+O ACC Manager precisa oferecer uma interface Windows para controlar arquivos
+locais do ACC, ler telemetria e editar setups. O criador inteligente e o
+calibrador também gravam dados em `core/data/*.json`.
+
+## Decisão
+
+Usar PyQt6 para a interface, organizar a janela em mixins por aba e distribuir
+o executável com PyInstaller no modo `--onedir`.
+
+## Consequências
+
+- `main.py` permanece pequeno e a UI é dividida por responsabilidade.
+- `core/` pode ser exercitado sem conhecer os widgets.
+- `--onedir` mantém `core/data` e `assets` como arquivos ao lado do executável,
+  permitindo que calibrações persistam.
+- A distribuição exige enviar a pasta inteira, não apenas o `.exe`.
+- Uma futura migração para widgets independentes é possível, mas não é
+  necessária para o comportamento atual.


### PR DESCRIPTION
Adiciona a estrutura para contribuidores externos sem alterar o código funcional: guia de contribuição, documentação real da arquitetura e módulos, roadmap, ADR, mapa de contribuidores, sugestões de issues, templates GitHub, CODEOWNERS, Dependabot e workflows de validação/build. A validação Python passou; não há testes automatizados existentes.