### PR TITLE
Add normalize rating scale test

### DIFF
--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.data_loader import normalize
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1, -1.0),
+        (3, 0.0),
+        (5, 1.0),
+    ],
+)
+def test_normalize_maps_rating_scale_to_signed_range(value: int, expected: float) -> None:
+    assert normalize(value) == expected


### PR DESCRIPTION
## Summary
- add parameterized coverage for the 1, 3, and 5 rating boundaries
- verify that `normalize` maps them to -1.0, 0.0, and 1.0

## Validation
- `uv run --with pytest pytest tests/test_data_loader.py -q`
- `python3 -m compileall -q core/data_loader.py tests/test_data_loader.py`

Closes #9