### PR TITLE
Fix telemetry tab syntax error

### DIFF
--- a/ui/telemetry_tab.py
+++ b/ui/telemetry_tab.py
@@ -215,9 +215,16 @@ class TelemetryTabMixin:
         v_weight = lap.get("vehicle_weight", "N/A")
 
         if not lap.get("is_valid", True):
+            glitch_message = ui(
+                "O tempo de {lap_time} em {track} e fisicamente impossivel para um "
+                "carro classe GT3.\nA sessao foi invalidada pelo sistema e recebeu "
+                "Score 0/10.",
+                lap_time=lap["lap_time"],
+                track=lap["track"],
+            ).replace("\n", "<br>")
             html = f"""
             <h3 style="color:#ff3b30;">{ui('ALERTA DE TEMPO IRREAL (GLITCH)')}</h3>
-            <p>{ui('O tempo de {lap_time} em {track} e fisicamente impossivel para um carro classe GT3.\nA sessao foi invalidada pelo sistema e recebeu Score 0/10.', lap_time=lap['lap_time'], track=lap['track']).replace(chr(10), '<br>')}</p>
+            <p>{glitch_message}</p>
             """
             self.motec_details.setHtml(html)
             return


### PR DESCRIPTION
## Summary\n- move the translated glitch message out of the f-string expression\n- preserve the existing line-break-to-HTML behavior\n\n## Validation\n- python -m compileall -q config.py core ui main.py test_discord_webhook.py tests\n- python -m pytest -q tests (3 passed)\n\nThis fixes the pre-existing Python quality workflow failure affecting main and feature branches.