### PR TITLE
Fix MoTeC refresh and add parser coverage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,98 @@
+# Copilot instructions for ACC Manager
+
+## Project overview
+
+ACC Manager is a Windows desktop application built with Python 3.10+ and PyQt6. It does not have a separate backend service; the app assembles UI and calls direct local/REST integrations from the `core/` layer.
+
+The repository layout follows a simple split:
+
+- `main.py` starts the Qt application and opens `ACCManagerApp`.
+- `config.py` loads `.env`, resolves runtime paths, exposes app settings, and imports core services. It is the central configuration entry point.
+- `ui/` contains the Qt window, tabs, dialogs, translations, and styling.
+- `core/` contains domain logic: server control, telemetry parsing, setup management, leaderboard sync, and Discord notifications.
+- `core/data/` provides car and track metadata used throughout the app.
+- `assets/` contains images and the application icon.
+
+The project is intentionally organized around multiple tab mixins in `ui/main_window.py`; keep those responsibilities separated from the business logic under `core/`.
+
+## Build, test, and validation commands
+
+Set up the environment from the repo root:
+
+```powershell
+python -m venv venv
+.\venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Run the app locally:
+
+```powershell
+python main.py
+```
+
+Compile the Python sources (used by CI and the contribution guide):
+
+```powershell
+python -m compileall -q config.py core ui main.py test_discord_webhook.py
+```
+
+Run the test suite:
+
+```powershell
+python -m pytest -q
+```
+
+Run a single test file:
+
+```powershell
+python -m pytest -q tests/test_data_loader.py
+```
+
+Run a specific test or keyword selection:
+
+```powershell
+python -m pytest -q tests/test_data_loader.py -k normalize
+```
+
+Build the Windows distributable:
+
+```powershell
+.\build_exe.bat
+```
+
+This creates `dist\ACCManager\ACCManager.exe` and follows the repo’s `--onedir` packaging approach described in `EMPACOTAMENTO.md`.
+
+## High-level architecture
+
+The app is a single desktop process with a Qt UI shell and service modules that call external tools directly:
+
+- `ui/main_window.py` creates the app window, enables/disables tabs, manages `ui_settings.json`, and swaps languages.
+- `ui/*.py` tab modules represent specific product areas such as server control, telemetry, setups, and leaderboard.
+- `core/server_controller.py` manages ACC server configuration and execution.
+- `core/motec_parser.py` and `core/ld_telemetry_parser.py` parse MoTeC telemetry and `.ld` files.
+- `core/setup_manager.py` and `core/setup_creator.py` handle setup storage and generation.
+- `core/leaderboard_client.py` communicates with Supabase and stores leaderboard data.
+- `core/discord_notifier.py` posts alerts and embeds via webhook.
+- `core/data_loader.py` is the single source of truth for the tracked car and track metadata.
+
+`.env` contains local paths, optional credentials, and module toggles. `ui_settings.json` stores UI-level values that are not meant to be treated as code. In runtime, `config.reload_env()` can rebuild app state without restarting the whole app.
+
+## Key conventions specific to this repo
+
+- Keep UI code in `ui/` and business logic in `core/`; do not mix heavy logic into Qt widgets.
+- When changing user-visible text, add the key to all supported languages in `ui/i18n.py` instead of only one locale.
+- Do not commit secrets, `.env` values, webhook URLs, real telemetry data, or generated files.
+- Prefer focused changes and short feature/fix/docs branches from `main`.
+- Before broad edits, consult `docs/START_HERE.md`, `docs/ARCHITECTURE.md`, and `CONTRIBUTING.md`.
+- Preserve third-party legal constraints: `core/vendor/ldparser.py` remains under its own GPLv3 license and should not be redistributed without respecting that license.
+- The project already uses automated validation in CI (`.github/workflows/quality.yml`), but the repo’s own guidance still treats `python -m compileall` and `pytest` as the minimum validation steps for PRs.
+
+## Relevant docs
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `docs/START_HERE.md`
+- `docs/ARCHITECTURE.md`
+- `EMPACOTAMENTO.md`

--- a/EMPACOTAMENTO.md
+++ b/EMPACOTAMENTO.md
@@ -6,16 +6,24 @@
    que rodar no Windows - nao da pra gerar um .exe Windows a partir de
    Linux/Mac).
 2. De dois cliques em `build_exe.bat` (ou rode `build_exe.bat` no
-   PowerShell/CMD dentro da pasta do projeto).
+  PowerShell/CMD dentro da pasta do projeto). Esse arquivo usa o launcher
+  `py`, cria a `venv` automaticamente e instala o PyInstaller e todas as
+  dependencias antes do empacotamento.
 3. Espere - a primeira vez demora mais porque instala tudo do zero
    (PyQt6, numpy etc. dentro de uma venv nova).
 4. Pronto: o app fica em `dist\ACCManager\ACCManager.exe`.
+
+Para iniciar o programa, use `run_acc_manager.bat`. Ele abre o executavel
+empacotado e nao exige Python no computador do usuario. O `run_acc_manager.bat`
+so tenta `python main.py` quando o executavel ainda nao foi gerado, como
+fallback para desenvolvimento.
 
 ## Distribuindo pros seus amigos
 
 Zipe e mande a pasta **inteira** `dist\ACCManager`, nao so o `.exe`. Ela
 contem:
 - `ACCManager.exe`
+- `run_acc_manager.bat`, para iniciar com duplo clique
 - As bibliotecas Python empacotadas (PyQt6, numpy etc.)
 - `core\data\cars.json` e `tracks.json` (a base de carros/pistas)
 - `assets\` (imagens de previa das pistas)

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -1,5 +1,5 @@
 @echo off
-setlocal
+setlocal EnableExtensions
 cd /d "%~dp0"
 
 echo ===============================================
@@ -7,23 +7,41 @@ echo   ACC Manager - Build do executavel (.exe)
 echo ===============================================
 echo.
 
-if not exist venv (
-    echo Criando ambiente virtual...
-    python -m venv venv
+where py >nul 2>&1
+if errorlevel 1 (
+    echo [ERRO] Python nao encontrado.
+    echo Instale Python 3.10+ e marque "Add Python to PATH".
+    pause
+    exit /b 1
 )
 
-call venv\Scripts\activate.bat
+if not exist venv (
+    echo Criando ambiente virtual...
+    py -3 -m venv venv
+    if errorlevel 1 (
+        echo [ERRO] Nao foi possivel criar a ambiente virtual.
+        pause
+        exit /b 1
+    )
+)
+
+set "PYTHON=%~dp0venv\Scripts\python.exe"
+if not exist "%PYTHON%" (
+    echo [ERRO] Python da virtualenv nao encontrado: "%PYTHON%"
+    pause
+    exit /b 1
+)
 
 echo Instalando dependencias (isso pode demorar na primeira vez)...
-python -m pip install --upgrade pip >nul
-pip install -r requirements.txt
-pip install pyinstaller
+"%PYTHON%" -m pip install --upgrade pip
+if errorlevel 1 goto :build_error
+"%PYTHON%" -m pip install -r requirements.txt pyinstaller
+if errorlevel 1 goto :build_error
 
 echo.
 echo Limpando builds anteriores...
 if exist build rmdir /s /q build
 if exist dist rmdir /s /q dist
-if exist ACCManager.spec del ACCManager.spec
 
 echo.
 echo Empacotando (modo --onedir)...
@@ -34,7 +52,7 @@ echo  extrai tudo pra uma pasta temporaria que e apagada ao fechar o
 echo  programa, e essas gravacoes se perderiam.)
 echo.
 
-pyinstaller ^
+"%PYTHON%" -m PyInstaller ^
     --name ACCManager ^
     --onedir ^
     --icon "assets\icon.ico" ^
@@ -56,6 +74,10 @@ if errorlevel 1 (
     exit /b 1
 )
 
+if not exist "dist\ACCManager\ACCManager.exe" goto :build_error
+copy /y "run_acc_manager.bat" "dist\ACCManager\run_acc_manager.bat" >nul
+if errorlevel 1 goto :build_error
+
 echo.
 echo ===============================================
 echo   PRONTO! O executavel esta em:
@@ -64,5 +86,17 @@ echo.
 echo   IMPORTANTE: distribua a pasta INTEIRA "dist\ACCManager"
 echo   pros seus amigos, nao so o .exe sozinho - ela contem os
 echo   dados (core\data, assets) e as bibliotecas empacotadas.
+echo   O arquivo run_acc_manager.bat tambem foi copiado para essa pasta.
 echo ===============================================
 pause
+exit /b 0
+
+:build_error
+echo.
+echo ============================================================
+echo   O BUILD FALHOU. Confira a mensagem acima.
+echo   Para diagnosticar, troque --windowed por --console no
+echo   comando do PyInstaller e execute este arquivo novamente.
+echo ============================================================
+pause
+exit /b 1

--- a/core/motec_parser.py
+++ b/core/motec_parser.py
@@ -32,6 +32,31 @@ class MotecParser:
             return float(hours) * 3600 + float(minutes) * 60 + float(seconds)
         return float(cleaned)
 
+    @staticmethod
+    def _detail_value(details, name, default=""):
+        """Busca campos MoTeC sem depender de caixa ou espacos extras."""
+        wanted = " ".join(str(name).split()).casefold()
+        for key, value in details.items():
+            if " ".join(str(key).split()).casefold() == wanted:
+                return value if value is not None else default
+        return default
+
+    def _fastest_marker_time(self, file_path):
+        """Calcula a melhor volta quando o resumo final ainda nao existe."""
+        try:
+            root = ET.parse(file_path).getroot()
+            times = sorted(
+                float(marker.get("Time"))
+                for marker in root.iter("Marker")
+                if marker.get("ClassName") == "BCN" and marker.get("Time")
+            )
+        except (ET.ParseError, TypeError, ValueError):
+            return 0.0
+
+        if len(times) < 2:
+            return 0.0
+        return min((end - start) / 1_000_000.0 for start, end in zip(times, times[1:]))
+
     def _normalize_track_name(self, track_id):
         if not track_id:
             return "Desconhecida"
@@ -93,13 +118,13 @@ class MotecParser:
                         details[node_id] = value
 
             summary["details"] = details
-            summary["total_laps"] = int(details.get("Total Laps", 0) or 0)
-            summary["fastest_time"] = details.get("Fastest Time", "")
-            summary["fastest_lap"] = details.get("Fastest Lap", "")
-            summary["session_type"] = details.get("Session", "N/A")
-            summary["track_temp"] = details.get("Track Temperature", "N/A")
-            summary["ambient_temp"] = details.get("Ambient Temperature", "N/A")
-            summary["vehicle_weight"] = details.get("Vehicle Weight", "N/A")
+            summary["total_laps"] = int(self._detail_value(details, "Total Laps", 0) or 0)
+            summary["fastest_time"] = self._detail_value(details, "Fastest Time")
+            summary["fastest_lap"] = self._detail_value(details, "Fastest Lap")
+            summary["session_type"] = self._detail_value(details, "Session", "N/A")
+            summary["track_temp"] = self._detail_value(details, "Track Temperature", "N/A")
+            summary["ambient_temp"] = self._detail_value(details, "Ambient Temperature", "N/A")
+            summary["vehicle_weight"] = self._detail_value(details, "Vehicle Weight", "N/A")
 
         except Exception:
             pass
@@ -119,6 +144,11 @@ class MotecParser:
             try:
                 summary = self.read_session_file(file_path)
                 fastest_time_value = summary.get("fastest_time")
+                if not fastest_time_value:
+                    marker_time = self._fastest_marker_time(file_path)
+                    if marker_time > 0:
+                        fastest_time_value = marker_time
+                        summary["fastest_time"] = marker_time
                 if not fastest_time_value:
                     continue
 
@@ -158,9 +188,8 @@ class MotecParser:
         return results
 
     def delete_telemetry(self, file_path):
-        if os.path.exists(file_path):
-            os.remove(file_path)
-        
-        ld_path = file_path.replace(".ldx", ".ld")
-        if os.path.exists(ld_path):
-            os.remove(ld_path)
+        base, _extension = os.path.splitext(file_path)
+        paths = (file_path, base + ".ld")
+        for path in paths:
+            if os.path.exists(path):
+                os.remove(path)

--- a/run_acc_manager.bat
+++ b/run_acc_manager.bat
@@ -1,9 +1,32 @@
 @echo off
+setlocal EnableExtensions
 cd /d "%~dp0"
-python main.py
-if errorlevel 1 (
-    echo.
-    echo Falha na execucao do app.
-    echo Verifique se o Python e as dependencias estao instaladas.
-    pause
+
+set "APP=%~dp0dist\ACCManager\ACCManager.exe"
+if not exist "%APP%" set "APP=%~dp0ACCManager.exe"
+if exist "%APP%" (
+    start "ACC Manager" "%APP%"
+    exit /b 0
 )
+
+echo O executavel empacotado nao foi encontrado:
+echo "%APP%"
+echo.
+echo Execute build_exe.bat nesta pasta para gerar a versao distribuivel.
+echo O fallback abaixo e apenas para desenvolvimento e exige Python e dependencias.
+where python >nul 2>&1
+if errorlevel 1 goto :missing_python
+python main.py
+if errorlevel 1 goto :run_error
+exit /b 0
+
+:missing_python
+echo Python nao encontrado. Para usar este .bat sem Python, distribua a pasta dist\ACCManager.
+pause
+exit /b 1
+
+:run_error
+echo.
+echo Falha na execucao do app em modo desenvolvimento.
+pause
+exit /b 1

--- a/tests/test_motec_parser.py
+++ b/tests/test_motec_parser.py
@@ -1,0 +1,70 @@
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from core.motec_parser import MotecParser
+
+
+def _write_ldx(path: Path, xml_text: str) -> None:
+    path.write_text(xml_text, encoding="utf-8")
+
+
+def test_read_session_file_parses_summary_and_metadata(tmp_path):
+    xml_text = """
+    <Session>
+      <String Id="Session" Value="Race" />
+      <String Id="Fastest Time" Value="01:45.678" />
+      <Number Id="Total Laps" Value="14" />
+      <String Id="Track Temperature" Value="27" />
+      <String Id="Ambient Temperature" Value="22" />
+      <String Id="Vehicle Weight" Value="1300" />
+    </Session>
+    """
+    file_path = tmp_path / "Monza-gt3-Driver-2024.05.18-12.30.00.ldx"
+    _write_ldx(file_path, xml_text)
+
+    summary = MotecParser(str(tmp_path)).read_session_file(str(file_path))
+
+    assert summary["total_laps"] == 14
+    assert summary["fastest_time"] == "01:45.678"
+    assert summary["session_type"] == "Race"
+    assert summary["track_temp"] == "27"
+    assert summary["ambient_temp"] == "22"
+    assert summary["vehicle_weight"] == "1300"
+
+
+def test_get_best_laps_uses_marker_fallback_and_filename_metadata(tmp_path):
+    xml_text = """
+    <Root>
+      <Marker ClassName="BCN" Time="1000000" />
+      <Marker ClassName="BCN" Time="2000000" />
+      <Marker ClassName="BCN" Time="3000000" />
+      <Marker ClassName="BCN" Time="4300000" />
+    </Root>
+    """
+    file_path = tmp_path / "silverstone-porsche_911_gt3_r-Driver-2024.06.02-18.30.00.ldx"
+    _write_ldx(file_path, xml_text)
+
+    laps = MotecParser(str(tmp_path)).get_best_laps()
+
+    assert len(laps) == 1
+    lap = laps[0]
+    assert lap["track"] == "Silverstone"
+    assert lap["car"] == "Porsche 911 Gt3 R" or lap["car"].startswith("Porsche")
+    assert lap["driver"] == "Driver"
+    assert lap["date"] == "02/06/2024 18:30"
+    assert lap["raw_time"] == 1.0
+    assert lap["lap_time"].startswith("0:01")
+
+
+def test_read_session_file_handles_missing_file_and_invalid_xml(tmp_path):
+    missing_summary = MotecParser(str(tmp_path)).read_session_file(str(tmp_path / "missing.ldx"))
+    assert missing_summary["total_laps"] == 0
+    assert missing_summary["fastest_time"] == ""
+
+    invalid_file = tmp_path / "broken.ldx"
+    invalid_file.write_text("<Root><Broken>", encoding="utf-8")
+
+    invalid_summary = MotecParser(str(tmp_path)).read_session_file(str(invalid_file))
+    assert invalid_summary["total_laps"] == 0
+    assert invalid_summary["fastest_time"] == ""
+    assert invalid_summary["session_type"] == "Desconhecida"

--- a/ui/i18n.py
+++ b/ui/i18n.py
@@ -64,6 +64,8 @@ def ui(text: str, **kwargs) -> str:
 
 
 RAW_TRANSLATIONS = {
+    "Filtrar tabela": {"pt": "Filtrar tabela", "en": "Filter table", "de": "Tabelle filtern"},
+    "Filtrar {column} (vazio remove):": {"pt": "Filtrar {column} (vazio remove):", "en": "Filter {column} (empty clears):", "de": "{column} filtern (leer loescht):"},
     "Recarregar Tempos MoTeC": {"pt": "Recarregar Tempos MoTeC", "en": "Reload MoTeC Laps", "de": "MoTeC-Zeiten neu laden"},
     "Deletar Sessao Selecionada": {"pt": "Deletar Sessao Selecionada", "en": "Delete Selected Session", "de": "Ausgewaehlte Sitzung loeschen"},
     "Telemetria Avancada (.ld)": {"pt": "Telemetria Avancada (.ld)", "en": "Advanced Telemetry (.ld)", "de": "Erweiterte Telemetrie (.ld)"},

--- a/ui/leaderboard_tab.py
+++ b/ui/leaderboard_tab.py
@@ -13,6 +13,7 @@ from PyQt6.QtWidgets import (
 
 from config import TRACKS_DATABASE, CAR_NAMES_MAPPING
 from ui.i18n import ui, t
+from ui.table_filters import apply_header_filters, install_header_filters, table_item
 
 
 class LeaderboardTabMixin:
@@ -76,6 +77,7 @@ class LeaderboardTabMixin:
             ["#", ui("Piloto"), ui("Carro"), ui("Pista"), ui("Melhor Volta"), ui("Enviado em")]
         )
         self.table_leaderboard.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        install_header_filters(self.table_leaderboard)
         layout.addWidget(self.table_leaderboard)
 
         note = QLabel(
@@ -167,16 +169,39 @@ class LeaderboardTabMixin:
             return
 
         best_rows = self.leaderboard.best_per_driver(rows)
-        self.table_leaderboard.setRowCount(len(best_rows))
-        for i, r in enumerate(best_rows):
-            display_car = r.get("car_id", "")
-            display_track = TRACKS_DATABASE.get(r.get("track_id", ""), r.get("track_id", ""))
-            self.table_leaderboard.setItem(i, 0, QTableWidgetItem(str(i + 1)))
-            self.table_leaderboard.setItem(i, 1, QTableWidgetItem(r.get("driver_name", "")))
-            self.table_leaderboard.setItem(i, 2, QTableWidgetItem(display_car))
-            self.table_leaderboard.setItem(i, 3, QTableWidgetItem(display_track))
-            self.table_leaderboard.setItem(i, 4, QTableWidgetItem(r.get("lap_time_formatted", "")))
-            self.table_leaderboard.setItem(i, 5, QTableWidgetItem(str(r.get("recorded_at", ""))[:16].replace("T", " ")))
+        self.table_leaderboard.setSortingEnabled(False)
+        try:
+            self.table_leaderboard.setRowCount(len(best_rows))
+            for i, r in enumerate(best_rows):
+                display_car = r.get("car_id", "")
+                display_track = TRACKS_DATABASE.get(r.get("track_id", ""), r.get("track_id", ""))
+                self.table_leaderboard.setItem(i, 0, table_item(i + 1, i + 1))
+                self.table_leaderboard.setItem(i, 1, table_item(r.get("driver_name", "")))
+                self.table_leaderboard.setItem(i, 2, table_item(display_car))
+                self.table_leaderboard.setItem(i, 3, table_item(display_track))
+                self.table_leaderboard.setItem(i, 4, table_item(r.get("lap_time_formatted", ""), self._parse_lap_time(r.get("lap_time_seconds"))))
+                recorded_at = str(r.get("recorded_at", ""))[:16].replace("T", " ")
+                self.table_leaderboard.setItem(i, 5, table_item(recorded_at, self._parse_recorded_at(recorded_at)))
+        finally:
+            self.table_leaderboard.setSortingEnabled(True)
+
+        apply_header_filters(self.table_leaderboard)
+
+    @staticmethod
+    def _parse_lap_time(value):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    @staticmethod
+    def _parse_recorded_at(value):
+        from datetime import datetime
+
+        try:
+            return datetime.strptime(value, "%Y-%m-%d %H:%M").timestamp()
+        except (TypeError, ValueError, OverflowError):
+            return 0
 
     # ==========================
     # METODOS SERVIDOR E UI

--- a/ui/setups_tab.py
+++ b/ui/setups_tab.py
@@ -22,6 +22,7 @@ from PyQt6.QtGui import QColor
 from config import TRACKS_DATABASE, CAR_NAMES_MAPPING, track_profile_calibrator
 from ui.dialogs import ReplicateDialog
 from ui.i18n import ui
+from ui.table_filters import apply_header_filters, install_header_filters, table_item
 
 
 class SetupsTabMixin:
@@ -63,6 +64,7 @@ class SetupsTabMixin:
         self.table_setups = QTableWidget(0, 3)
         self.table_setups.setHorizontalHeaderLabels([ui("Carro"), ui("Pista"), ui("Nome do Setup")])
         self.table_setups.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        install_header_filters(self.table_setups)
         self.table_setups.itemSelectionChanged.connect(self.show_selected_setup_details)
         main_splitter.addWidget(self.table_setups)
 
@@ -207,13 +209,19 @@ class SetupsTabMixin:
         track_val = self.setup_track_filter.currentText()
 
         setups = self.setup_mgr.get_filtered_setups(car_val, track_val)
-        self.table_setups.setRowCount(len(setups))
-        for row, s in enumerate(setups):
-            display_car = CAR_NAMES_MAPPING.get(s["car"].lower(), s["car"].replace("_", " ").title())
-            self.table_setups.setItem(row, 0, QTableWidgetItem(display_car))
-            self.table_setups.setItem(row, 1, QTableWidgetItem(s["track"]))
-            self.table_setups.setItem(row, 2, QTableWidgetItem(s["name"]))
-            self.table_setups.item(row, 0).setData(Qt.ItemDataRole.UserRole, s)
+        self.table_setups.setSortingEnabled(False)
+        try:
+            self.table_setups.setRowCount(len(setups))
+            for row, s in enumerate(setups):
+                display_car = CAR_NAMES_MAPPING.get(s["car"].lower(), s["car"].replace("_", " ").title())
+                self.table_setups.setItem(row, 0, table_item(display_car))
+                self.table_setups.setItem(row, 1, table_item(s["track"]))
+                self.table_setups.setItem(row, 2, table_item(s["name"]))
+                self.table_setups.item(row, 0).setData(Qt.ItemDataRole.UserRole, s)
+        finally:
+            self.table_setups.setSortingEnabled(True)
+
+        apply_header_filters(self.table_setups)
 
     def show_selected_setup_details(self):
         if not self.table_setups.selectedItems(): return

--- a/ui/table_filters.py
+++ b/ui/table_filters.py
@@ -1,0 +1,68 @@
+from PyQt6.QtWidgets import QInputDialog, QTableWidget, QTableWidgetItem
+from PyQt6.QtCore import Qt
+from ui.i18n import ui
+
+
+class SortableTableWidgetItem(QTableWidgetItem):
+    """Ordena pelo valor tipado quando ele existe."""
+
+    def __lt__(self, other):
+        left = self.data(Qt.ItemDataRole.UserRole + 1)
+        right = other.data(Qt.ItemDataRole.UserRole + 1)
+        if left is not None and right is not None:
+            try:
+                return left < right
+            except TypeError:
+                pass
+        return super().__lt__(other)
+
+
+def table_item(text, sort_value=None):
+    item = SortableTableWidgetItem(str(text))
+    if sort_value is not None:
+        item.setData(Qt.ItemDataRole.UserRole + 1, sort_value)
+    return item
+
+
+def install_header_filters(table: QTableWidget) -> None:
+    """Keeps single-click sorting and opens filters on double-click."""
+    table.setSortingEnabled(True)
+    table.setProperty("column_filters", {})
+    table.horizontalHeader().sectionDoubleClicked.connect(
+        lambda column: _prompt_column_filter(table, column)
+    )
+
+
+def apply_header_filters(table: QTableWidget) -> None:
+    filters = table.property("column_filters") or {}
+    for row in range(table.rowCount()):
+        visible = True
+        for column, value in filters.items():
+            item = table.item(row, column)
+            if item is None or value.casefold() not in item.text().casefold():
+                visible = False
+                break
+        table.setRowHidden(row, not visible)
+
+
+def _prompt_column_filter(table: QTableWidget, column: int) -> None:
+    header = table.horizontalHeaderItem(column)
+    column_name = header.text() if header else "coluna"
+    filters = table.property("column_filters") or {}
+    current = filters.get(column, "")
+    value, accepted = QInputDialog.getText(
+        table,
+        ui("Filtrar tabela"),
+        ui("Filtrar {column} (vazio remove):", column=column_name),
+        text=current,
+    )
+    if not accepted:
+        return
+
+    value = value.strip()
+    if value:
+        filters[column] = value
+    else:
+        filters.pop(column, None)
+    table.setProperty("column_filters", filters)
+    apply_header_filters(table)

--- a/ui/telemetry_tab.py
+++ b/ui/telemetry_tab.py
@@ -18,6 +18,7 @@ from PyQt6.QtGui import QColor, QPixmap
 from core import ld_telemetry_parser
 from ui.server_tab import ResizableImageLabel
 from ui.i18n import ui
+from ui.table_filters import apply_header_filters, install_header_filters, table_item
 
 class TelemetryTabMixin:
 
@@ -58,6 +59,7 @@ class TelemetryTabMixin:
         self.table_motec = QTableWidget(0, 6)
         self.table_motec.setHorizontalHeaderLabels([ui("Pista"), ui("Piloto"), ui("Carro"), ui("Melhor Volta"), ui("Score"), ui("Data")])
         self.table_motec.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        install_header_filters(self.table_motec)
         self.table_motec.itemSelectionChanged.connect(self.show_selected_motec_details)
         splitter.addWidget(self.table_motec)
 
@@ -113,33 +115,48 @@ class TelemetryTabMixin:
                 if t not in track_records or rt < track_records[t]:
                     track_records[t] = rt
 
-        self.table_motec.setRowCount(len(laps))
-        for row, lap in enumerate(laps):
-            rt = lap["raw_time"]
-            if rt < 70.0:
-                lap["is_valid"] = False
-                lap["score"] = 0.0
-            else:
-                lap["is_valid"] = True
-                tr = track_records.get(lap["track"], rt)
-                pace_score = (tr / rt) * 5.0
-                cons_score = min(5.0, lap.get("total_laps", 0) / 2.0)
-                lap["score"] = round(pace_score + cons_score, 1)
+        self.table_motec.setSortingEnabled(False)
+        try:
+            self.table_motec.setRowCount(len(laps))
+            for row, lap in enumerate(laps):
+                rt = lap["raw_time"]
+                if rt < 70.0:
+                    lap["is_valid"] = False
+                    lap["score"] = 0.0
+                else:
+                    lap["is_valid"] = True
+                    tr = track_records.get(lap["track"], rt)
+                    pace_score = (tr / rt) * 5.0
+                    cons_score = min(5.0, lap.get("total_laps", 0) / 2.0)
+                    lap["score"] = round(pace_score + cons_score, 1)
 
-            self.table_motec.setItem(row, 0, QTableWidgetItem(lap["track"]))
-            self.table_motec.setItem(row, 1, QTableWidgetItem(lap["driver"]))
-            self.table_motec.setItem(row, 2, QTableWidgetItem(lap["car"]))
-            self.table_motec.setItem(row, 3, QTableWidgetItem(lap["lap_time"]))
+                self.table_motec.setItem(row, 0, table_item(lap["track"]))
+                self.table_motec.setItem(row, 1, table_item(lap["driver"]))
+                self.table_motec.setItem(row, 2, table_item(lap["car"]))
+                self.table_motec.setItem(row, 3, table_item(lap["lap_time"], rt))
 
-            score_item = QTableWidgetItem(f"{lap['score']}/10")
-            if not lap["is_valid"]:
-                score_item.setForeground(QColor("#ff3b30"))
-            self.table_motec.setItem(row, 4, score_item)
+                score_item = table_item(f"{lap['score']}/10", lap["score"])
+                if not lap["is_valid"]:
+                    score_item.setForeground(QColor("#ff3b30"))
+                self.table_motec.setItem(row, 4, score_item)
 
-            self.table_motec.setItem(row, 5, QTableWidgetItem(lap["date"]))
+                self.table_motec.setItem(row, 5, table_item(lap["date"], self._parse_display_date(lap["date"])))
 
-            # Armazena os dados completos para o display lateral
-            self.table_motec.item(row, 0).setData(Qt.ItemDataRole.UserRole, lap)
+                # Armazena os dados completos para o display lateral
+                self.table_motec.item(row, 0).setData(Qt.ItemDataRole.UserRole, lap)
+        finally:
+            self.table_motec.setSortingEnabled(True)
+
+        apply_header_filters(self.table_motec)
+
+    @staticmethod
+    def _parse_display_date(value):
+        from datetime import datetime
+
+        try:
+            return datetime.strptime(value, "%d/%m/%Y %H:%M").timestamp()
+        except (TypeError, ValueError, OverflowError):
+            return 0
 
     def show_advanced_telemetry(self):
         if not self.table_motec.selectedItems():
@@ -267,6 +284,8 @@ class TelemetryTabMixin:
         if reply == QMessageBox.StandardButton.Yes:
             try:
                 self.motec.delete_telemetry(lap["file_path"])
+                self.table_motec.clearSelection()
+                self.refresh_motec_filters()
                 self.refresh_motec_table()
                 self.motec_img_label.clear()
                 self.motec_details.clear()


### PR DESCRIPTION
## Summary
- add table filtering and typed sorting support across telemetry, setups, and leaderboard tables
- fix MoTeC refresh fallback when Fastest Time is absent by deriving lap times from markers
- add parser tests for XML summaries, metadata fallbacks, invalid/missing files, and filename dates
- update Windows packaging scripts and project instructions

## Validation
- python -m compileall -q config.py core ui main.py test_discord_webhook.py
- python -m pytest -q tests